### PR TITLE
修正 Session 驅動設定

### DIFF
--- a/config/session.php
+++ b/config/session.php
@@ -18,7 +18,7 @@ return [
     |
     */
 
-    'driver' => env('SESSION_DRIVER', 'database'),
+    'driver' => env('SESSION_DRIVER', 'file'),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## 摘要
- 將 `config/session.php` 的預設 `SESSION_DRIVER` 調整為 `file`

## 測試
- `composer test`（失敗：無法下載依賴）

------
https://chatgpt.com/codex/tasks/task_e_688b06b0c0e48322ab3ced00c8eb55e1