### PR TITLE
新增查詢UserData頁面

### DIFF
--- a/app/Http/Controllers/UserDataController.php
+++ b/app/Http/Controllers/UserDataController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\UserData;
+use Illuminate\Http\Request;
+
+class UserDataController extends Controller
+{
+    public function index(Request $request)
+    {
+        $query = UserData::query();
+        $search = $request->input('q');
+        if ($search) {
+            $query->where(function ($q) use ($search) {
+                $q->where('u_idno', 'like', "%{$search}%")
+                  ->orWhere('u_name', 'like', "%{$search}%")
+                  ->orWhere('u_company', 'like', "%{$search}%");
+            });
+        }
+        $users = $query->paginate(10);
+        return view('userdata.index', ['users' => $users, 'search' => $search]);
+    }
+}

--- a/app/Models/UserData.php
+++ b/app/Models/UserData.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class UserData extends Model
+{
+    protected $table = 'userdatas';
+
+    protected $fillable = [
+        'u_idno',
+        'u_name',
+        'u_passwd',
+        'u_org',
+        'u_auth',
+        'u_mail',
+        'c_name',
+        'c_tel',
+        'u_company',
+        'u_status',
+        'chCreateDate',
+        'chUpdateDate',
+        'nextAgency',
+    ];
+
+    public $timestamps = true;
+    const CREATED_AT = 'chCreateDate';
+    const UPDATED_AT = 'chUpdateDate';
+}

--- a/database/migrations/2025_07_31_000001_create_userdatas_table.php
+++ b/database/migrations/2025_07_31_000001_create_userdatas_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('userdatas', function (Blueprint $table) {
+            $table->id();
+            $table->string('u_idno', 15)->unique();
+            $table->string('u_name', 20);
+            $table->string('u_passwd', 15);
+            $table->string('u_org', 20)->nullable();
+            $table->string('u_auth', 5)->nullable();
+            $table->text('u_mail')->nullable();
+            $table->string('c_name', 20)->nullable();
+            $table->string('c_tel', 50)->nullable();
+            $table->text('u_company')->nullable();
+            $table->string('u_status', 5)->default('1');
+            $table->timestamp('chCreateDate')->nullable();
+            $table->timestamp('chUpdateDate')->nullable();
+            $table->string('nextAgency', 20)->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('userdatas');
+    }
+};

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>PumpManager</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-100 text-gray-900">
+    @yield('content')
+</body>
+</html>

--- a/resources/views/userdata/index.blade.php
+++ b/resources/views/userdata/index.blade.php
@@ -1,0 +1,35 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">UserData 查詢</h1>
+    <form method="get" class="mb-4">
+        <input type="text" name="q" value="{{ $search }}" placeholder="搜尋使用者..." class="border rounded p-2 w-full md:w-1/3" />
+    </form>
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead>
+                <tr>
+                    <th class="px-4 py-2 text-left">帳號</th>
+                    <th class="px-4 py-2 text-left">名稱</th>
+                    <th class="px-4 py-2 text-left">公司名稱</th>
+                    <th class="px-4 py-2 text-left">狀態</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @foreach($users as $user)
+                <tr>
+                    <td class="px-4 py-2">{{ $user->u_idno }}</td>
+                    <td class="px-4 py-2">{{ $user->u_name }}</td>
+                    <td class="px-4 py-2">{{ $user->u_company }}</td>
+                    <td class="px-4 py-2">{{ $user->u_status }}</td>
+                </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+    <div class="mt-4">
+        {{ $users->withQueryString()->links() }}
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,3 +5,6 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+use App\Http\Controllers\UserDataController;
+
+Route::get('/userdata', [UserDataController::class, 'index'])->name('userdata.index');


### PR DESCRIPTION
## 摘要
- 建立 `userdatas` 資料表遷移與 `UserData` 模型
- 新增 `UserDataController` 及對應路由
- 加入簡易 `layouts.app` 版型與 `userdata` 查詢頁面

## 測試
- `php artisan test` 執行失敗，顯示缺少 `vendor/autoload.php`

------
https://chatgpt.com/codex/tasks/task_e_688b096864848322b85679cf786aa408