### PR TITLE
更新 UserData 檢視頁面

### DIFF
--- a/app/Http/Controllers/UserDataController.php
+++ b/app/Http/Controllers/UserDataController.php
@@ -10,15 +10,24 @@ class UserDataController extends Controller
     public function index(Request $request)
     {
         $query = UserData::query();
-        $search = $request->input('q');
-        if ($search) {
-            $query->where(function ($q) use ($search) {
-                $q->where('u_idno', 'like', "%{$search}%")
-                  ->orWhere('u_name', 'like', "%{$search}%")
-                  ->orWhere('u_company', 'like', "%{$search}%");
-            });
+
+        $account = $request->input('account');
+        $name = $request->input('name');
+
+        if ($account) {
+            $query->where('u_idno', 'like', "%{$account}%");
         }
-        $users = $query->paginate(10);
-        return view('userdata.index', ['users' => $users, 'search' => $search]);
+
+        if ($name) {
+            $query->where('u_name', 'like', "%{$name}%");
+        }
+
+        $users = $query->paginate(10)->appends($request->only('account', 'name'));
+
+        return view('userdata.index', [
+            'users' => $users,
+            'account' => $account,
+            'name' => $name,
+        ]);
     }
 }

--- a/resources/views/userdata/index.blade.php
+++ b/resources/views/userdata/index.blade.php
@@ -3,8 +3,11 @@
 @section('content')
 <div class="container mx-auto p-4">
     <h1 class="text-2xl font-bold mb-4">UserData 查詢</h1>
-    <form method="get" class="mb-4">
-        <input type="text" name="q" value="{{ $search }}" placeholder="搜尋使用者..." class="border rounded p-2 w-full md:w-1/3" />
+    <form method="get" class="mb-4 flex flex-col md:flex-row md:items-center gap-2">
+        <input type="text" name="account" value="{{ $account }}" placeholder="搜尋帳號" class="border rounded p-2 md:w-1/3" />
+        <input type="text" name="name" value="{{ $name }}" placeholder="搜尋名稱" class="border rounded p-2 md:w-1/3" />
+        <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">搜尋</button>
+        <a href="{{ route('userdata.index') }}" class="text-blue-500 ml-2">清除</a>
     </form>
     <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-gray-200">
@@ -17,19 +20,23 @@
                 </tr>
             </thead>
             <tbody class="divide-y divide-gray-200">
-                @foreach($users as $user)
+                @forelse($users as $user)
                 <tr>
                     <td class="px-4 py-2">{{ $user->u_idno }}</td>
                     <td class="px-4 py-2">{{ $user->u_name }}</td>
                     <td class="px-4 py-2">{{ $user->u_company }}</td>
                     <td class="px-4 py-2">{{ $user->u_status }}</td>
                 </tr>
-                @endforeach
+                @empty
+                <tr>
+                    <td colspan="4" class="px-4 py-2 text-center">無資料</td>
+                </tr>
+                @endforelse
             </tbody>
         </table>
     </div>
-    <div class="mt-4">
-        {{ $users->withQueryString()->links() }}
+    <div class="mt-4 flex justify-center">
+        {{ $users->links() }}
     </div>
 </div>
 @endsection


### PR DESCRIPTION
## 變更內容
- 提供帳號與名稱個別的搜尋欄位
- 顯示公司名稱與狀態並處理無資料情況
- 分頁按鈕置中顯示

## 測試結果
- `php artisan test` 由於缺少依賴而無法執行


------
https://chatgpt.com/codex/tasks/task_e_688b2fc4d11c83228e3a16e1e365edb2