### PR TITLE
更新使用者資料搜尋區塊

### DIFF
--- a/resources/views/userdata/index.blade.php
+++ b/resources/views/userdata/index.blade.php
@@ -3,12 +3,38 @@
 @section('content')
 <div class="container mx-auto p-4">
     <h1 class="text-2xl font-bold mb-4">UserData 查詢</h1>
-    <form method="get" class="mb-4 flex flex-col md:flex-row md:items-center gap-2">
-        <input type="text" name="account" value="{{ $account }}" placeholder="搜尋帳號" class="border rounded p-2 md:w-1/3" />
-        <input type="text" name="name" value="{{ $name }}" placeholder="搜尋名稱" class="border rounded p-2 md:w-1/3" />
-        <button type="submit" class="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded">搜尋</button>
-        <a href="{{ route('userdata.index') }}" class="text-blue-500 ml-2">清除</a>
-    </form>
+    <div class="bg-white p-4 rounded shadow mb-4">
+        <form method="get" class="grid gap-4 md:grid-cols-3 items-end">
+            <div>
+                <label for="account" class="block text-sm font-medium text-gray-700">帳號</label>
+                <input id="account" type="text" name="account" value="{{ $account }}" placeholder="搜尋帳號"
+                    class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+            </div>
+            <div>
+                <label for="name" class="block text-sm font-medium text-gray-700">名稱</label>
+                <input id="name" type="text" name="name" value="{{ $name }}" placeholder="搜尋名稱"
+                    class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" />
+            </div>
+            <div class="flex gap-2">
+                <button type="submit"
+                    class="flex items-center justify-center gap-1 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24"
+                        stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+                    </svg>
+                    <span>搜尋</span>
+                </button>
+                <a href="{{ route('userdata.index') }}"
+                    class="flex items-center justify-center gap-1 bg-gray-100 hover:bg-gray-200 text-gray-700 px-4 py-2 rounded-md">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24"
+                        stroke="currentColor" stroke-width="2">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+                    </svg>
+                    <span>清除</span>
+                </a>
+            </div>
+        </form>
+    </div>
     <div class="overflow-x-auto">
         <table class="min-w-full divide-y divide-gray-200">
             <thead>


### PR DESCRIPTION
## 變更內容
- 改善 `UserData` 檢視頁的搜尋區塊排版
- 新增圖示按鈕讓搜尋與清除操作更直覺

## 測試
- `composer run test` *(失敗：缺少 `vendor` 依賴)*

------
https://chatgpt.com/codex/tasks/task_e_688b31caea4c8322812df4851fb03fe5