### PR TITLE
更改 UserData 搜尋與清除按鈕顏色

### DIFF
--- a/resources/views/userdata/index.blade.php
+++ b/resources/views/userdata/index.blade.php
@@ -17,7 +17,7 @@
             </div>
             <div class="flex gap-2">
                 <button type="submit"
-                    class="flex items-center justify-center gap-1 bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md">
+                    class="flex items-center justify-center gap-1 bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24"
                         stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -25,7 +25,7 @@
                     <span>搜尋</span>
                 </button>
                 <a href="{{ route('userdata.index') }}"
-                    class="flex items-center justify-center gap-1 bg-gray-100 hover:bg-gray-200 text-gray-700 px-4 py-2 rounded-md">
+                    class="flex items-center justify-center gap-1 bg-gray-400 hover:bg-gray-500 text-white px-4 py-2 rounded-md">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24"
                         stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
## 變更內容
- 調整 `resources/views/userdata/index.blade.php` 中搜尋與清除按鈕的背景色，讓顏色更深，提升可讀性

## 測試狀態
- 嘗試執行 `composer test` 但因環境限制無法下載相依套件，測試未能順利執行


------
https://chatgpt.com/codex/tasks/task_e_688c0c25f11c8322a123bfc984c33470