### PR TITLE
調整搜尋區塊按鈕顏色

### DIFF
--- a/resources/views/userdata/index.blade.php
+++ b/resources/views/userdata/index.blade.php
@@ -17,7 +17,7 @@
             </div>
             <div class="flex gap-2">
                 <button type="submit"
-                    class="flex items-center justify-center gap-1 bg-indigo-600 hover:bg-indigo-700 text-white px-4 py-2 rounded-md">
+                    class="flex items-center justify-center gap-1 bg-indigo-800 hover:bg-indigo-900 text-white px-4 py-2 rounded-md">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24"
                         stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
@@ -25,7 +25,7 @@
                     <span>搜尋</span>
                 </button>
                 <a href="{{ route('userdata.index') }}"
-                    class="flex items-center justify-center gap-1 bg-gray-400 hover:bg-gray-500 text-white px-4 py-2 rounded-md">
+                    class="flex items-center justify-center gap-1 bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24"
                         stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />


### PR DESCRIPTION
## 變更內容
- 調整 `userdata` 搜尋頁的搜尋與清除按鈕的顏色，使按鈕更為醒目

## 測試結果
- `composer test` 因缺少套件無法執行，顯示找不到 `vendor/autoload.php`
- 嘗試安裝套件時需要連線至 GitHub，因環境限制失敗

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_688c0eee26e083229174bcffe6229c9b