### PR TITLE
新增 PumpData 查詢

### DIFF
--- a/app/Http/Controllers/PumpdataController.php
+++ b/app/Http/Controllers/PumpdataController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Pumpdata;
+use Illuminate\Http\Request;
+
+class PumpdataController extends Controller
+{
+    public function index()
+    {
+        $pumps = Pumpdata::select('pd_id','pd_arg','o_id','pd_idno','pd_name','pd_proptyorg','pd_mngorg')->paginate(10);
+
+        return view('pumpdata.index', [
+            'pumps' => $pumps,
+        ]);
+    }
+}

--- a/app/Models/Pumpdata.php
+++ b/app/Models/Pumpdata.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Pumpdata extends Model
+{
+    protected $table = 'pumpdatas';
+    protected $primaryKey = 'pd_id';
+
+    protected $fillable = [
+        'pd_arg',
+        'o_id',
+        'pd_idno',
+        'pd_name',
+        'pd_proptyorg',
+        'pd_mngorg',
+    ];
+
+    public $timestamps = true;
+    const CREATED_AT = 'chCreateDate';
+    const UPDATED_AT = 'chUpdateDate';
+}

--- a/database/migrations/2025_07_31_000002_create_pumpdatas_table.php
+++ b/database/migrations/2025_07_31_000002_create_pumpdatas_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pumpdatas', function (Blueprint $table) {
+            $table->increments('pd_id');
+            $table->text('pd_arg')->nullable();
+            $table->integer('o_id');
+            $table->string('pd_idno', 20);
+            $table->string('pd_name', 20);
+            $table->string('pd_proptyorg', 20)->nullable();
+            $table->string('pd_mngorg', 20)->nullable();
+            $table->timestamp('chCreateDate')->nullable();
+            $table->timestamp('chUpdateDate')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pumpdatas');
+    }
+};

--- a/resources/views/pumpdata/index.blade.php
+++ b/resources/views/pumpdata/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">PumpData 查詢</h1>
+    <div class="overflow-x-auto">
+        <table class="min-w-full divide-y divide-gray-200">
+            <thead>
+                <tr>
+                    <th class="px-4 py-2 text-left">ID</th>
+                    <th class="px-4 py-2 text-left">加密ID</th>
+                    <th class="px-4 py-2 text-left">組織ID</th>
+                    <th class="px-4 py-2 text-left">編號</th>
+                    <th class="px-4 py-2 text-left">抽水機名稱</th>
+                    <th class="px-4 py-2 text-left">財產機關</th>
+                    <th class="px-4 py-2 text-left">管理機關</th>
+                </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-200">
+                @forelse($pumps as $pump)
+                <tr>
+                    <td class="px-4 py-2">{{ $pump->pd_id }}</td>
+                    <td class="px-4 py-2">{{ $pump->pd_arg }}</td>
+                    <td class="px-4 py-2">{{ $pump->o_id }}</td>
+                    <td class="px-4 py-2">{{ $pump->pd_idno }}</td>
+                    <td class="px-4 py-2">{{ $pump->pd_name }}</td>
+                    <td class="px-4 py-2">{{ $pump->pd_proptyorg }}</td>
+                    <td class="px-4 py-2">{{ $pump->pd_mngorg }}</td>
+                </tr>
+                @empty
+                <tr>
+                    <td colspan="7" class="px-4 py-2 text-center">無資料</td>
+                </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+    <div class="mt-4 flex justify-center">
+        {{ $pumps->links() }}
+    </div>
+</div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,5 +6,7 @@ Route::get('/', function () {
     return view('welcome');
 });
 use App\Http\Controllers\UserDataController;
+use App\Http\Controllers\PumpdataController;
 
 Route::get('/userdata', [UserDataController::class, 'index'])->name('userdata.index');
+Route::get('/pumpdata', [PumpdataController::class, 'index'])->name('pumpdata.index');


### PR DESCRIPTION
## 變更內容
- 新增 `Pumpdata` 模型與資料表 migration
- 新增 `PumpdataController` 及對應路由與視圖
- 在畫面中列出 `Pumpdata` 重要欄位

## 測試結果
- `composer test` 無法執行，因為缺少 `vendor` 依賴

------
https://chatgpt.com/codex/tasks/task_e_688c27c247448322add163a7660b12b8