### PR TITLE
新增 UserData 建立功能

### DIFF
--- a/app/Http/Controllers/UserDataController.php
+++ b/app/Http/Controllers/UserDataController.php
@@ -30,4 +30,24 @@ class UserDataController extends Controller
             'name' => $name,
         ]);
     }
+
+    public function create()
+    {
+        return view('userdata.create');
+    }
+
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'u_idno' => 'required|string|max:15|unique:userdatas,u_idno',
+            'u_name' => 'required|string|max:20',
+            'u_passwd' => 'required|string|max:15',
+            'u_company' => 'nullable|string',
+            'u_status' => 'required|string|max:5',
+        ]);
+
+        UserData::create($validated);
+
+        return redirect()->route('userdata.index');
+    }
 }

--- a/resources/views/userdata/create.blade.php
+++ b/resources/views/userdata/create.blade.php
@@ -1,0 +1,37 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold mb-4">新增使用者</h1>
+    <form method="post" action="{{ route('userdata.store') }}" class="bg-white p-4 rounded shadow grid gap-4 md:grid-cols-2">
+        @csrf
+        <div>
+            <label for="u_idno" class="block text-sm font-medium text-gray-700">帳號</label>
+            <input id="u_idno" name="u_idno" type="text" value="{{ old('u_idno') }}" class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" required>
+        </div>
+        <div>
+            <label for="u_name" class="block text-sm font-medium text-gray-700">名稱</label>
+            <input id="u_name" name="u_name" type="text" value="{{ old('u_name') }}" class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" required>
+        </div>
+        <div>
+            <label for="u_passwd" class="block text-sm font-medium text-gray-700">密碼</label>
+            <input id="u_passwd" name="u_passwd" type="password" class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500" required>
+        </div>
+        <div>
+            <label for="u_company" class="block text-sm font-medium text-gray-700">公司名稱</label>
+            <input id="u_company" name="u_company" type="text" value="{{ old('u_company') }}" class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+        </div>
+        <div>
+            <label for="u_status" class="block text-sm font-medium text-gray-700">狀態</label>
+            <select id="u_status" name="u_status" class="mt-1 w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500">
+                <option value="1" {{ old('u_status')=='1' ? 'selected' : '' }}>啟用</option>
+                <option value="0" {{ old('u_status')=='0' ? 'selected' : '' }}>停用</option>
+            </select>
+        </div>
+        <div class="md:col-span-2 flex gap-2">
+            <button type="submit" class="bg-blue-700 hover:bg-blue-800 text-white px-4 py-2 rounded-md">儲存</button>
+            <a href="{{ route('userdata.index') }}" class="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md">取消</a>
+        </div>
+    </form>
+</div>
+@endsection

--- a/resources/views/userdata/index.blade.php
+++ b/resources/views/userdata/index.blade.php
@@ -3,6 +3,9 @@
 @section('content')
 <div class="container mx-auto p-4">
     <h1 class="text-2xl font-bold mb-4">UserData 查詢</h1>
+    <div class="mb-4">
+        <a href="{{ route('userdata.create') }}" class="bg-blue-700 hover:bg-blue-800 text-white px-4 py-2 rounded-md">新增使用者</a>
+    </div>
     <div class="bg-white p-4 rounded shadow mb-4">
         <form method="get" class="grid gap-4 md:grid-cols-3 items-end">
             <div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,4 +9,6 @@ use App\Http\Controllers\UserDataController;
 use App\Http\Controllers\PumpdataController;
 
 Route::get('/userdata', [UserDataController::class, 'index'])->name('userdata.index');
+Route::get('/userdata/create', [UserDataController::class, 'create'])->name('userdata.create');
+Route::post('/userdata', [UserDataController::class, 'store'])->name('userdata.store');
 Route::get('/pumpdata', [PumpdataController::class, 'index'])->name('pumpdata.index');


### PR DESCRIPTION
## 變更內容
- 新增用戶資料建立表單頁面
- 新增對應路由及控制器 create、store 方法
- 在列表頁加入前往建立頁面的連結

## 測試
- `phpunit` *(執行失敗：找不到套件)*

------
https://chatgpt.com/codex/tasks/task_e_688c542645088322b8ce937356944b25